### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 12 * * 6" # Tous les samedis à midi
   workflow_dispatch: # Permet de lancer manuellement
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/arnaudroubinet/krabotnotif/security/code-scanning/17](https://github.com/arnaudroubinet/krabotnotif/security/code-scanning/17)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are necessary:
- `contents: write` for committing changes and pushing branches.
- `pull-requests: write` for creating and merging pull requests.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as all jobs in this workflow require similar permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
